### PR TITLE
Re-map XS-conflicting keyboard shortcuts.

### DIFF
--- a/EditorComfortAddin/Properties/Manifest.addin.xml
+++ b/EditorComfortAddin/Properties/Manifest.addin.xml
@@ -28,14 +28,14 @@
 		<Command id="TwinTechs.EditorExtensions.Commands.PreviousMember"
 			_label="Previous Member"
 			_description="Goes to the previous member in a code file"
-			shortcut="Shift|Ctrl|Up"
+			shortcut="Shift|Ctrl|Alt|Up"
 			macShortcut="Ctrl|Up"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.PreviousMember" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.NextMember"
 			_label="Next Member"
 			_description="Goes to the next member in a code file"
-			shortcut="Shift|Ctrl|Down"
+			shortcut="Shift|Ctrl|Alt|Down"
 			macShortcut="Ctrl|Down"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.NextMember" />
 

--- a/EditorComfortAddin/Properties/Manifest.addin.xml
+++ b/EditorComfortAddin/Properties/Manifest.addin.xml
@@ -77,7 +77,7 @@
 		<Command id="TwinTechs.EditorExtensions.Commands.FixNamespace"
 			_label="Fix Namespace"
 			_description="Sets namespace to match file location"
-			shortcut="Alt|Meta|n"
+			shortcut="Alt|Ctrl|n"
 			macShortcut="Alt|Meta|n"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.FixNamespace" />
 	</Extension>

--- a/EditorComfortAddin/Properties/Manifest.addin.xml
+++ b/EditorComfortAddin/Properties/Manifest.addin.xml
@@ -7,15 +7,15 @@
 		<Command id="TwinTechs.EditorExtensions.Commands.BrowseRecentDocument"
 			_label="Browse recent documents"
 			_description="Browse recently opened documents"
-			shortcut="Meta|E"
-			macShortcut="Meta|E"
+			shortcut="Ctrl|E"
+			macShortcut="Ctrl|E"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.ShowRecentDocumentBrowser" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.GoToDeclarationPlus"
 			_label="Go to Declaration+"
 			_description="Advanced version of go to declaration. Can go direct to implementing classes, and some Xaml types."
-			shortcut="Meta|b"
-			macShortcut="Meta|b"
+			shortcut="Alt|D"
+			macShortcut="Ctrl|D"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.GoToDeclarationPlus" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.ShowMembers"
@@ -28,14 +28,14 @@
 		<Command id="TwinTechs.EditorExtensions.Commands.PreviousMember"
 			_label="Previous Member"
 			_description="Goes to the previous member in a code file"
-			shortcut="Ctrl|Up"
+			shortcut="Shift|Ctrl|Up"
 			macShortcut="Ctrl|Up"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.PreviousMember" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.NextMember"
 			_label="Next Member"
 			_description="Goes to the next member in a code file"
-			shortcut="Ctrl|Down"
+			shortcut="Shift|Ctrl|Down"
 			macShortcut="Ctrl|Down"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.NextMember" />
 

--- a/EditorComfortAddin/Properties/Manifest.addin.xml
+++ b/EditorComfortAddin/Properties/Manifest.addin.xml
@@ -42,35 +42,35 @@
 		<Command id="TwinTechs.EditorExtensions.Commands.CycleViewModelXamlCodeBehind"
 			_label="Cycle VM/Xaml/Code behind"
 			_description="Cycles between the vm and xaml file and code behind files"
-			shortcut="Shift|Meta|F8"
+			shortcut="Shift|Alt|F8"
 			macShortcut="Shift|Meta|F8"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.CycleViewModelXamlCodeBehind" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.ToggleViewModel"
 			_label="Cycle VM/Xaml"
 			_description="Cycles between the vm and xaml file"
-			shortcut="Shift|Meta|F9"
+			shortcut="Shift|Alt|F9"
 			macShortcut="Shift|Meta|F9"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.ToggleViewModel" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.ToggleVMAndCodeBehind"
 			_label="Cycle VM/Code-behind"
 			_description="Will cycle through the VM and code-behind file"
-			shortcut="Shift|Meta|F10"
+			shortcut="Shift|Alt|F10"
 			macShortcut="Shift|Meta|F10"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.ToggleVMAndCodeBehind" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.ToggleUnitTestAndImplementation"
 			_label="Toggle Unit Tests"
 			_description="Will toggle the Unit test and implementation file"
-			shortcut="Alt|Meta|t"
+			shortcut="Alt|Ctrl|t"
 			macShortcut="Alt|Meta|t"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.ToggleUnitTestAndImplementation" />
 
 		<Command id="TwinTechs.EditorExtensions.Commands.CreateUnitTestForMethod"
 			_label="Generate Unit Test"
 			_description="Create unit test for current method"
-			shortcut="Shift|Alt|Meta|t"
+			shortcut="Shift|Alt|Ctrl|t"
 			macShortcut="Shift|Alt|Meta|t"
 			defaultHandler="TwinTechs.EditorExtensions.Commands.CreateUnitTestForMethod" />
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The add-in provides the following features:
   * Toggle class/unit test file, and go to correct method in each
   * Generate unit test for current method in implementation file
   
-Please check the default hotkeys and be prepared to reconfigure, as they are currently to my preference and may not be to yours.
+Please check the [default hotkeys and be prepared to reconfigure](#keyboard-shortcut-defaults).
 
 ## Overview
 
@@ -54,6 +54,41 @@ You will find an overview video here : [https://www.youtube.com/watch?v=_sYSDFR0
   * If a method is named `SomeMethod` then your tests must be called `TestSomeMethod` or `Test_SomeMethod`
   * You can have multiple methods, and add more stuff to the end of the name e.g. `Test_SomeMethod_InvalidEntryScenarios`
   * Generated methods are named `Test_MethodName`
+
+## Keyboard Shortcut Defaults
+
+Please check the default hotkeys and be prepared to reconfigure; they are currently a blend of IntelliJ and some work to avoid Xamarin Studio defaults on Win/Mac.
+
+  * Browse recent documents
+    * Mac: <kbd>Ctrl</kbd>+<kbd>E</kbd>
+    * Windows: <kbd>Ctrl</kbd>+<kbd>E</kbd>
+  * Go to Declaration+
+    * Mac: <kbd>Ctrl</kbd>+<kbd>D</kbd>
+    * Windows: <kbd>Alt</kbd>+<kbd>D</kbd>
+  * Show Members
+    * Mac: <kbd>Ctrl</kbd>+<kbd>F12</kbd>
+    * Windows: <kbd>Ctrl</kbd>+<kbd>F12</kbd>
+  * Previous/Next Member
+    * Mac: <kbd>Ctrl</kbd>+<kbd>Up</kbd> / <kbd>Ctrl</kbd>+<kbd>Down</kbd>
+    * Windows: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Up</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Down</kbd>
+  * Cycle VM/Xaml/Code behind
+    * Mac: <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>F8</kbd>
+    * Windows: <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F8</kbd>
+  * Cycle VM/Xaml
+    * Mac: <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>F9</kbd>
+    * Windows: <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F9</kbd>
+  * Cycle VM/Code-behind
+    * Mac: <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>F10</kbd>
+    * Windows: <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F10</kbd>
+  * Toggle Unit Tests
+    * Mac: <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>T</kbd>
+    * Windows: <kbd>Alt</kbd>+<kbd>Ctrl</kbd>+<kbd>T</kbd>
+  * Generate Unit Test
+    * Mac: <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>
+    * Windows: {[still requires binding](https://github.com/twintechs/TwinToolsForXamarin/pull/4#issuecomment-197352035)}
+  * Fix Namespace
+    * Mac: <kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>N</kbd>
+    * Windows: <kbd>Alt</kbd>+<kbd>Ctrl</kbd>+<kbd>N</kbd>
   
 ## WIP features
 


### PR DESCRIPTION
Attempt to resolve issue #2.

Mac
- Browse recent documents => <kbd>Ctrl</kbd>+<kbd>E</kbd> (changed to eliminate conflict with "Find Next Selection")
- Go to Definition+ => <kbd>Ctrl</kbd>+<kbd>D</kbd> (changed to eliminate conflict with "Build All")

PC
- Browse recent documents => <kbd>Ctrl</kbd>+<kbd>E</kbd> (only changed to keep consistent letter with Mac)
- Go to Definition+ => <kbd>Alt</kbd>+<kbd>D</kbd> (wanted to make consistent letter with Mac, but had to use Alt instead of Ctrl to avoid conflict with "Breakpoints")
- Previous Member => <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Up</kbd> (changed to eliminate conflict with "Scroll line up")
- Next Member => <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Down</kbd> (changed to eliminate conflict with "Scroll line down")
